### PR TITLE
Correct the readme and add host option for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ roles:
       mariadb_ensure_users:
         wordpress:
           password: wp
-          privileges: "wordpress:*:ALL"
+          privileges: "wordpress.*:ALL"
         admin:
-          privileges: "*:*:ALL"
+          privileges: "*.*:ALL"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ List of database names
 
 ### mariadb_ensure_users
 
-Dict of users. Each key is a username and the value is a dict with two keys:
+Dict of users. Each key is a username and the value is a dict with up to three
+keys:
 
 - `password` - Optional password
+- `host` - Optional host which the user can access the DB from
 - `privileges` - Ansible-style MariaDB privilege configuration
 
 ## Example Playbook
@@ -45,6 +47,9 @@ roles:
           privileges: "wordpress.*:ALL"
         admin:
           privileges: "*.*:ALL"
+        public_account:
+          privileges: "public.*:ALL"
+          host: "192.168.1.%"
 ```
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,5 +29,6 @@
     name: "{{ item.key }}"
     password: "{{ item.value['password'] | default(omit) }}"
     priv: "{{ item.value['privileges'] | default(omit) }}"
+    host: "{{ item.value['host'] | default(omit) }}"
   no_log: True
   loop: "{{ mariadb_ensure_users |dict2items }}"


### PR DESCRIPTION
Readme has two small mistakes (':' should be '.')

I think the `host` option should be included for user accounts.