### PR TITLE
chore(mysql_db): Ansible 2.10 compatibility for mysql_db

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,7 +20,7 @@
   when: ansible_service_mgr == "systemd" and reload_mariadb.changed
 
 - name: Ensure configured databases exist
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ item }}"
   with_items: "{{ mariadb_ensure_databases }}"
 


### PR DESCRIPTION
Since Ansible 2.10, `mysql_db` is no longer a part of Ansible. It can be obtained from the Ansible Galaxy collection `community.mysql`. Note that this change probably breaks compatibility with Ansible <= 2.8.