### PR TITLE
fix(install): Remove legacy package

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,6 @@
   apt:
     name:
       - mariadb-server
-      - python-mysqldb
       - python3-mysqldb
 
 - name: Copy config file


### PR DESCRIPTION
It is no longer included in modern debian causing errors